### PR TITLE
Fixed deadlock in csp_rdp_send()

### DIFF
--- a/src/csp_conn.h
+++ b/src/csp_conn.h
@@ -77,7 +77,7 @@ typedef struct {
 /** @brief Connection struct */
 struct csp_conn_s {
 	csp_conn_type_t type;		/* Connection type (CONN_CLIENT or CONN_SERVER) */
-	csp_conn_state_t state;		/* Connection state (SOCKET_OPEN or SOCKET_CLOSED) */
+	csp_conn_state_t state;		/* Connection state (CONN_OPEN or CONN_CLOSED) */
 	csp_mutex_t lock;		/* Connection structure lock */
 	csp_id_t idin;			/* Identifier received */
 	csp_id_t idout;			/* Identifier transmitted */


### PR DESCRIPTION
Basically fixed by using the same check in "wake up" and "sleep tx" -> csp_rdp_is_conn_ready_for_tx().

The "wake up" in csp_rdp_check_timeouts () would always wake up the tx, because it checked against a windows size * 2 - and in slightly different way.

Tested by flooding task A with messages from B, and doing no receive in A. Once A's queue is full, no acks will be sent and the Bs Tx windows fills up. Before the fix, this test deadlocked because the timeout check always woke up the B Tx. After the fix, the tests failed due to timeout.