### PR TITLE
can: Use the MTU of the interface instead of a macro.

### DIFF
--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -57,8 +57,8 @@ extern "C" {
 				 CFP_MAKE_DST((uint32_t)(1 << CFP_HOST_SIZE) - 1) | \
 				 CFP_MAKE_ID((uint32_t)(1 << CFP_ID_SIZE) - 1))
 
-/* Maximum Transmission Unit for CSP over CAN */
-#define CSP_CAN_MTU	256
+/* Default Maximum Transmission Unit for CSP over CAN */
+#define CSP_CAN_DEFAULT_MTU	256
 
 int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc, CSP_BASE_TYPE *task_woken);
 int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout);

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -61,7 +61,7 @@ static struct can_socketcan_s {
 		.interface = {
 			.name = "CAN",
 			.nexthop = csp_can_tx,
-			.mtu = CSP_CAN_MTU,
+			.mtu = CSP_CAN_DEFAULT_MTU,
 			.driver = &socketcan[0],
 		},
 	},

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -119,9 +119,9 @@ int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t
 		} else {
 			/* Allocate memory for frame */
 			if (task_woken == NULL) {
-				buf->packet = csp_buffer_get(CSP_CAN_MTU);
+				buf->packet = csp_buffer_get(interface->mtu);
 			} else {
-				buf->packet = csp_buffer_get_isr(CSP_CAN_MTU);
+				buf->packet = csp_buffer_get_isr(interface->mtu);
 			}
 			if (buf->packet == NULL) {
 				//csp_log_error("Failed to get buffer for CSP_BEGIN packet");


### PR DESCRIPTION
This allows the application to override the MTU for applications that
need to send/receive big CSP messages on the CAN interface.