### PR TITLE
fix missing headers when using install option

### DIFF
--- a/wscript
+++ b/wscript
@@ -3,7 +3,7 @@
 
 # Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
 # Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-# Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+# Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -30,7 +30,7 @@ out = 'build'
 def options(ctx):
     # Load GCC options
     ctx.load('gcc')
-    
+
     ctx.add_option('--toolchain', default=None, help='Set toolchain prefix')
 
     # Set libcsp options
@@ -56,7 +56,7 @@ def options(ctx):
     gr.add_option('--enable-if-kiss', action='store_true', help='Enable KISS/RS.232 interface')
     gr.add_option('--enable-if-can', action='store_true', help='Enable CAN interface')
     gr.add_option('--enable-if-zmqhub', action='store_true', help='Enable ZMQHUB interface')
-    
+
     # Drivers
     gr.add_option('--enable-can-socketcan', action='store_true', help='Enable Linux socketcan driver')
     gr.add_option('--with-driver-usart', default=None, metavar='DRIVER', help='Build USART driver. [windows, linux, None]')
@@ -116,7 +116,7 @@ def configure(ctx):
 
     # Add default files
     ctx.env.append_unique('FILES_CSP', ['src/*.c','src/interfaces/csp_if_lo.c','src/transport/csp_udp.c','src/arch/{0}/**/*.c'.format(ctx.options.with_os)])
-    
+
     # Store OS as env variable
     ctx.env.append_unique('OS', ctx.options.with_os)
 
@@ -129,7 +129,7 @@ def configure(ctx):
     # Check for recursion
     if ctx.path == ctx.srcnode:
         ctx.options.install_csp = True
-    
+
     # Windows build flags
     if ctx.options.with_os == 'windows':
         ctx.env.append_unique('CFLAGS', ['-D_WIN32_WINNT=0x0600'])
@@ -138,7 +138,7 @@ def configure(ctx):
     ctx.define_cond('CSP_POSIX', ctx.options.with_os == 'posix')
     ctx.define_cond('CSP_WINDOWS', ctx.options.with_os == 'windows')
     ctx.define_cond('CSP_MACOSX', ctx.options.with_os == 'macosx')
-        
+
     # Add CAN driver
     if ctx.options.enable_can_socketcan:
         ctx.env.append_unique('FILES_CSP', 'src/drivers/can/can_socketcan.c')
@@ -146,7 +146,7 @@ def configure(ctx):
     # Add USART driver
     if ctx.options.with_driver_usart != None:
         ctx.env.append_unique('FILES_CSP', 'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart))
-        
+
     # Interfaces
     if ctx.options.enable_if_can:
         ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_can.c')
@@ -194,7 +194,7 @@ def configure(ctx):
     if ctx.options.enable_xtea:
         ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_xtea.c')
         ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_sha1.c')
-        
+
     ctx.env.append_unique('FILES_CSP', 'src/rtable/csp_rtable_' + ctx.options.with_rtable  + '.c')
 
     ctx.define_cond('CSP_DEBUG', not ctx.options.disable_output)
@@ -217,7 +217,7 @@ def configure(ctx):
     ctx.define('CSP_RDP_MAX_WINDOW', ctx.options.with_rdp_max_window)
     ctx.define('CSP_PADDING_BYTES', ctx.options.with_padding)
     ctx.define('CSP_CONNECTION_SO', ctx.options.with_connection_so)
-    
+
     if ctx.options.with_bufalign != None:
         ctx.define('CSP_BUFFER_ALIGN', ctx.options.with_bufalign)
 
@@ -244,28 +244,17 @@ def configure(ctx):
     ctx.define('LIBCSP_VERSION', VERSION)
 
     ctx.write_config_header('include/csp/csp_autoconfig.h')
-    
+
 def build(ctx):
 
     # Set install path for header files
     install_path = False
     if ctx.options.install_csp:
         install_path = '${PREFIX}/lib'
-        ctx.install_files('${PREFIX}/include/csp', ctx.path.ant_glob('include/csp/*.h'))
-        ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_lo.h')
-
-        if 'src/interfaces/csp_if_can.c' in ctx.env.FILES_CSP:
-            ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_can.h')
-        if 'src/interfaces/csp_if_i2c.c' in ctx.env.FILES_CSP:
-            ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_i2c.h')
-        if 'src/interfaces/csp_if_kiss.c' in ctx.env.FILES_CSP:
-            ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_kiss.h')
-        if 'src/interfaces/csp_if_zmqhub.c' in ctx.env.FILES_CSP:
-            ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_zmqhub.h')
-        if 'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart) in ctx.env.FILES_CSP:
-            ctx.install_as('${PREFIX}/include/csp/drivers/usart.h', 'include/csp/drivers/usart.h')            
-        if 'src/drivers/can/can_socketcan.c' in ctx.env.FILES_CSP:
-            ctx.install_as('${PREFIX}/include/csp/drivers/can_socketcan.h', 'include/csp/drivers/can_socketcan.h')
+        ctx.install_files('${PREFIX}/include/csp',
+                          ctx.path.ant_glob('include/csp/**'),
+                          cwd=ctx.path.find_dir('include/csp'),
+                          relative_trick=True)
 
         ctx.install_files('${PREFIX}/include/csp', 'include/csp/csp_autoconfig.h', cwd=ctx.bldnode)
 


### PR DESCRIPTION
Maybe its just me but as a user I would expect the library to install all its headers. This PR changes the install behavior to that. When installing now I get the following (which fixes my issue of the arch headers missing.)

```
./usr/include/csp/interfaces
./usr/include/csp/interfaces/csp_if_lo.h
./usr/include/csp/interfaces/csp_if_kiss.h
./usr/include/csp/interfaces/csp_if_can.h
./usr/include/csp/interfaces/csp_if_i2c.h
./usr/include/csp/interfaces/csp_if_zmqhub.h
./usr/include/csp/csp_endian.h
./usr/include/csp/csp_crc32.h
./usr/include/csp/csp_interface.h
./usr/include/csp/csp_platform.h
./usr/include/csp/csp_autoconfig.h
./usr/include/csp/csp_rtable.h
./usr/include/csp/drivers
./usr/include/csp/drivers/i2c.h
./usr/include/csp/drivers/usart.h
./usr/include/csp/drivers/can_socketcan.h
./usr/include/csp/crypto
./usr/include/csp/crypto/csp_hmac.h
./usr/include/csp/crypto/csp_xtea.h
./usr/include/csp/crypto/csp_sha1.h
./usr/include/csp/arch
./usr/include/csp/arch/csp_queue.h
./usr/include/csp/arch/posix
./usr/include/csp/arch/posix/pthread_queue.h
./usr/include/csp/arch/csp_system.h
./usr/include/csp/arch/csp_clock.h
./usr/include/csp/arch/csp_semaphore.h
./usr/include/csp/arch/csp_time.h
./usr/include/csp/arch/csp_thread.h
./usr/include/csp/arch/csp_malloc.h
./usr/include/csp/csp_types.h
./usr/include/csp/csp_iflist.h
./usr/include/csp/csp_cmp.h
./usr/include/csp/csp_buffer.h
./usr/include/csp/csp_error.h
./usr/include/csp/csp.h
./usr/include/csp/csp_debug.h
```